### PR TITLE
Refactore after the mapper component name has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation on Symfony 2
 Add to your composer.json:
 ```json
 "require": {
-    "kassko/data-access-bundle": "~0.6.0@alpha"
+    "kassko/data-access-bundle": "~0.7.0@alpha"
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "~2.4",
         "symfony/twig-bundle": "~2.4",
         "zendframework/zend-stdlib": "~2.3",
-        "kassko/data-access": "~0.5.0@alpha",
+        "kassko/data-mapper": "~0.6.0@alpha",
         "kassko/class-resolver-bundle": "~0.1@alpha"
     },
     "autoload":{

--- a/src/Adapter/Cache/DoctrineCacheAdapter.php
+++ b/src/Adapter/Cache/DoctrineCacheAdapter.php
@@ -2,7 +2,7 @@
 
 namespace Kassko\Bundle\DataAccessBundle\Adapter\Cache;
 
-use Kassko\DataAccess\Cache\CacheInterface as KasskoCacheInterface;
+use Kassko\DataMapper\Cache\CacheInterface as KasskoCacheInterface;
 use Doctrine\Common\Cache\Cache as DoctrineCacheInterface;
 
 /**

--- a/src/DependencyInjection/KasskoDataAccessExtension.php
+++ b/src/DependencyInjection/KasskoDataAccessExtension.php
@@ -2,7 +2,7 @@
 
 namespace Kassko\Bundle\DataAccessBundle\DependencyInjection;
 
-use Kassko\DataAccess\Registry\Registry;
+use Kassko\DataMapper\Registry\Registry;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/KasskoDataAccessBundle.php
+++ b/src/KasskoDataAccessBundle.php
@@ -6,7 +6,7 @@ use Kassko\Bundle\DataAccessBundle\DependencyInjection\Compiler\InitializeRegist
 use Kassko\Bundle\DataAccessBundle\DependencyInjection\Compiler\RegisterClassToResolvePass;
 use Kassko\Bundle\DataAccessBundle\DependencyInjection\Compiler\RegisterListenersToResolvePass;
 use Kassko\Bundle\DataAccessBundle\DependencyInjection\Compiler\RegisterMappingLoadersPass;
-use Kassko\DataAccess\ClassMetadata\Events;
+use Kassko\DataMapper\ClassMetadata\Events;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/RegistryInitializer.php
+++ b/src/RegistryInitializer.php
@@ -2,7 +2,7 @@
 
 namespace Kassko\Bundle\DataAccessBundle;
 
-use Kassko\DataAccess\Registry\Registry;
+use Kassko\DataMapper\Registry\Registry;
 
 /**
  * Command (from Command pattern, not Symfony command) witch initialize the registry.

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,26 +5,26 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="kassko_data_access.object_manager.class">Kassko\DataAccess\ObjectManager</parameter>
-        <parameter key="kassko_data_access.object_listener_resolver.class">Kassko\DataAccess\Listener\ContainerAwareObjectListenerResolver</parameter>
-        <parameter key="kassko_data_access.hydrator.class">Kassko\DataAccess\Hydrator\Hydrator</parameter>
-        <parameter key="kassko_data_access.result_builder_factory.class">Kassko\DataAccess\Result\ResultBuilderFactory</parameter>
-        <parameter key="kassko_data_access.lazy_loader_factory.class">Kassko\DataAccess\LazyLoader\LazyLoaderFactory</parameter>
-        <parameter key="kassko_data_access.query_factory.class">Kassko\DataAccess\Query\QueryFactory</parameter>
+        <parameter key="kassko_data_access.object_manager.class">Kassko\DataMapper\ObjectManager</parameter>
+        <parameter key="kassko_data_access.object_listener_resolver.class">Kassko\DataMapper\Listener\ContainerAwareObjectListenerResolver</parameter>
+        <parameter key="kassko_data_access.hydrator.class">Kassko\DataMapper\Hydrator\Hydrator</parameter>
+        <parameter key="kassko_data_access.result_builder_factory.class">Kassko\DataMapper\Result\ResultBuilderFactory</parameter>
+        <parameter key="kassko_data_access.lazy_loader_factory.class">Kassko\DataMapper\LazyLoader\LazyLoaderFactory</parameter>
+        <parameter key="kassko_data_access.query_factory.class">Kassko\DataMapper\Query\QueryFactory</parameter>
         <parameter key="kassko_data_access.default_cache.class">Doctrine\Common\Cache\ArrayCache</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.annotation.class">Kassko\DataAccess\ClassMetadataLoader\AnnotationLoader</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.yaml_file.class">Kassko\DataAccess\ClassMetadataLoader\YamlFileLoader</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.php_file.class">Kassko\DataAccess\ClassMetadataLoader\PhpFileLoader</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.php.class">Kassko\DataAccess\ClassMetadataLoader\PhpLoader</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.yaml.class">Kassko\DataAccess\ClassMetadataLoader\YamlLoader</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.resolver.class">Kassko\DataAccess\ClassMetadataLoader\LoaderResolver</parameter>
-        <parameter key="kassko_data_access.class_metadata_loader.delegating_loader.class">Kassko\DataAccess\ClassMetadataLoader\DelegatingLoader</parameter>
-        <parameter key="kassko_data_access.configuration.class">Kassko\DataAccess\Configuration\ConfigurationChain</parameter>
-        <parameter key="kassko_data_access.configuration.cache.prototype.class">Kassko\DataAccess\Configuration\CacheConfiguration</parameter>
-        <parameter key="kassko_data_access.class_metadata_factory.class">Kassko\DataAccess\ClassMetadata\ClassMetadataFactory</parameter>
-        <parameter key="kassko_data_access.object_listener_resolver_chain.class">Kassko\DataAccess\Listener\ObjectListenerResolverChain</parameter>
-        <parameter key="kassko_data_access.cache_config.class">Kassko\DataAccess\Configuration\CacheConfig</parameter>
-        <parameter key="kassko_data_access.class_metadata_factory.configurator.class">Kassko\DataAccess\Configuration\ClassMetadataFactoryConfigurator</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.annotation.class">Kassko\DataMapper\ClassMetadataLoader\AnnotationLoader</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.yaml_file.class">Kassko\DataMapper\ClassMetadataLoader\YamlFileLoader</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.php_file.class">Kassko\DataMapper\ClassMetadataLoader\PhpFileLoader</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.php.class">Kassko\DataMapper\ClassMetadataLoader\PhpLoader</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.yaml.class">Kassko\DataMapper\ClassMetadataLoader\YamlLoader</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.resolver.class">Kassko\DataMapper\ClassMetadataLoader\LoaderResolver</parameter>
+        <parameter key="kassko_data_access.class_metadata_loader.delegating_loader.class">Kassko\DataMapper\ClassMetadataLoader\DelegatingLoader</parameter>
+        <parameter key="kassko_data_access.configuration.class">Kassko\DataMapper\Configuration\ConfigurationChain</parameter>
+        <parameter key="kassko_data_access.configuration.cache.prototype.class">Kassko\DataMapper\Configuration\CacheConfiguration</parameter>
+        <parameter key="kassko_data_access.class_metadata_factory.class">Kassko\DataMapper\ClassMetadata\ClassMetadataFactory</parameter>
+        <parameter key="kassko_data_access.object_listener_resolver_chain.class">Kassko\DataMapper\Listener\ObjectListenerResolverChain</parameter>
+        <parameter key="kassko_data_access.cache_config.class">Kassko\DataMapper\Configuration\CacheConfig</parameter>
+        <parameter key="kassko_data_access.class_metadata_factory.configurator.class">Kassko\DataMapper\Configuration\ClassMetadataFactoryConfigurator</parameter>
         <parameter key="kassko_data_access.container_aware_event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher</parameter>
 
     </parameters>

--- a/src/Resources/samples/Behaviour.php
+++ b/src/Resources/samples/Behaviour.php
@@ -2,7 +2,7 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
+use Kassko\DataMapper\Annotation as DA;
 
 class Behaviour
 {

--- a/src/Resources/samples/KeyBoard.php
+++ b/src/Resources/samples/KeyBoard.php
@@ -2,11 +2,11 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
-use Kassko\DataAccess\Hydrator\HydrationContextInterface;
-use Kassko\DataAccess\Hydrator\Value;
-use Kassko\DataAccess\ObjectExtension\LazyLoadableTrait;
-use Kassko\DataAccess\ObjectExtension\LoggableTrait;
+use Kassko\DataMapper\Annotation as DA;
+use Kassko\DataMapper\Hydrator\HydrationContextInterface;
+use Kassko\DataMapper\Hydrator\Value;
+use Kassko\DataMapper\ObjectExtension\LazyLoadableTrait;
+use Kassko\DataMapper\ObjectExtension\LoggableTrait;
 
 class Keyboard
 {

--- a/src/Resources/samples/RgbKeyboard.php
+++ b/src/Resources/samples/RgbKeyboard.php
@@ -2,7 +2,7 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
+use Kassko\DataMapper\Annotation as DA;
 
 class RgbKeyboard
 {

--- a/src/Resources/samples/RgbKeyboardCustomHyd.php
+++ b/src/Resources/samples/RgbKeyboardCustomHyd.php
@@ -2,7 +2,7 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
+use Kassko\DataMapper\Annotation as DA;
 
 /**
  * @DA\CustomHydrator(class="Solfa\Bundle\ScalesBundle\Scales\RgbKeyboardHydrator")

--- a/src/Resources/samples/RgbKeyboardInMemory.php
+++ b/src/Resources/samples/RgbKeyboardInMemory.php
@@ -2,7 +2,7 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
+use Kassko\DataMapper\Annotation as DA;
 
 class RgbKeyboardInMemory
 {

--- a/src/Resources/samples/Watch.php
+++ b/src/Resources/samples/Watch.php
@@ -2,9 +2,9 @@
 
 namespace Solfa\Bundle\ScalesBundle\Scales;
 
-use Kassko\DataAccess\Annotation as DA;
-use Kassko\DataAccess\Hydrator\HydrationContextInterface;
-use Kassko\DataAccess\Hydrator\Value;
+use Kassko\DataMapper\Annotation as DA;
+use Kassko\DataMapper\Hydrator\HydrationContextInterface;
+use Kassko\DataMapper\Hydrator\Value;
 use \DateTime;
 
 /**


### PR DESCRIPTION
Refactore the mapper component (name and namespace) after it has moved from data-access to data-mapper and from Kassko/DataAccess to Kassko/DataMapper.
