### PR TITLE
Update for data-mapper Core Breaking Change - Property `name` → `key`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "kassko/data-mapper": "^2.43-alpha@alpha",
+        "kassko/data-mapper": "^2.45-alpha@alpha",
         "psr/container": "^1.1|^2.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.1|^2.0|^3.0",

--- a/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
+++ b/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
@@ -1,0 +1,35 @@
+# PR: Update for data-mapper Core Breaking Change - Property `name` → `key`
+
+**Date:** 2026-01-03
+**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+
+## Summary
+
+This PR acknowledges the breaking change in `kassko/data-mapper` core library where the `name` field in `Property` and `PropertyConfig` attributes was renamed to `key`.
+
+## Core Library Change
+
+The core library (`kassko/data-mapper`) renamed:
+- `Property::$name` → `Property::$key`
+- `PropertyConfig::$name` → `PropertyConfig::$key`
+
+## Bundle Impact
+
+No direct code changes are required in the bundle as it does not use these attribute parameters directly.
+
+## Action Required
+
+Users of the bundle must update their entity classes:
+
+```php
+// Before
+#[Property(name: 'first_name')]
+
+// After
+#[Property(key: 'first_name')]
+```
+
+## Related
+
+- Core PR: `improv/dev/propertyFieldNameRenamingToKey`
+- [Property Documentation](../../../data-mapper/docs/attributes/Property.md)

--- a/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
+++ b/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
@@ -1,7 +1,7 @@
 # PR: Update for data-mapper Core Breaking Change - Property `name` → `key`
 
 **Date:** 2026-01-03
-**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+**Branch:** `sync/version/corePropertyFieldNameRenamingToKey`
 
 ## Summary
 

--- a/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
+++ b/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
@@ -1,0 +1,28 @@
+# Summary: Acknowledge Core Breaking Change - Property `name` → `key`
+
+**Date:** 2026-01-03
+**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+
+## Overview
+
+The core library `kassko/data-mapper` renamed the `name` field to `key` in `Property` and `PropertyConfig` attributes.
+
+## Bundle Changes
+
+No direct code changes were needed in the bundle.
+
+## User Migration Required
+
+Update entity classes:
+
+```php
+// Before
+#[Property(name: 'first_name')]
+
+// After
+#[Property(key: 'first_name')]
+```
+
+## Related
+
+- Core library branch: `improv/dev/propertyFieldNameRenamingToKey`

--- a/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
+++ b/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
@@ -1,7 +1,7 @@
 # Summary: Acknowledge Core Breaking Change - Property `name` → `key`
 
 **Date:** 2026-01-03
-**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+**Branch:** `sync/version/corePropertyFieldNameRenamingToKey`
 
 ## Overview
 


### PR DESCRIPTION
# PR: Update for data-mapper Core Breaking Change - Property `name` → `key`

**Date:** 2026-01-03
**Branch:** `sync/version/corePropertyFieldNameRenamingToKey`

## Summary

This PR acknowledges the breaking change in `kassko/data-mapper` core library where the `name` field in `Property` and `PropertyConfig` attributes was renamed to `key`.

## Core Library Change

The core library (`kassko/data-mapper`) renamed:
- `Property::$name` → `Property::$key`
- `PropertyConfig::$name` → `PropertyConfig::$key`

## Bundle Impact

No direct code changes are required in the bundle as it does not use these attribute parameters directly.

## Action Required

Users of the bundle must update their entity classes:

```php
// Before
#[Property(name: 'first_name')]

// After
#[Property(key: 'first_name')]
```

## Related

- Core PR: `improv/dev/propertyFieldNameRenamingToKey`
- [Property Documentation](../../../data-mapper/docs/attributes/Property.md)
